### PR TITLE
Ignore build/ and dist/.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /nbproject/private/
+
+build/
+dist/


### PR DESCRIPTION
Ignore folders build/ and dist/ to make it easier to see valuable changes in the current tree.