### PR TITLE
Manage colors automatically

### DIFF
--- a/src/Config.xml
+++ b/src/Config.xml
@@ -111,6 +111,15 @@
         <itemcolor name="%wio">
             <color>255,0,127</color>
         </itemcolor>
+        <itemcolor name="%irq">
+            <color>175,125,75</color>
+        </itemcolor>
+        <itemcolor name="%soft">
+            <color>125,75,175</color>
+        </itemcolor>
+        <itemcolor name="%guest">
+            <color>75,175,125</color>
+        </itemcolor>
 
         <itemcolor name="ldavg-1">
             <color>255,0,0</color>

--- a/src/Config.xml
+++ b/src/Config.xml
@@ -32,50 +32,8 @@
         <itemcolor name="mdmin/s">
             <color>255,0,255</color>
         </itemcolor>
-        <itemcolor name="%usr">
-            <color>0,255,0</color>
-        </itemcolor>
-        <itemcolor name="%sys">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name ="%system">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name="%user">
-            <color>0,255,0</color>
-        </itemcolor>
-        <itemcolor name="%idle">
-            <color>127,127,127</color>
-        </itemcolor>
-        <itemcolor name="%nice">
-            <color>255,255,0</color>
-        </itemcolor>
-        <itemcolor name="%steal">
-            <color>255,127,0</color>
-        </itemcolor>
-        <itemcolor name="%iowait">
-            <color>255,0,127</color>
-        </itemcolor>
-        <itemcolor name="%wio">
-            <color>255,0,127</color>
-        </itemcolor>
         <itemcolor name="intr/s">
             <color>255,127,127</color>
-        </itemcolor>
-        <itemcolor name="ldavg-1">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name="ldavg-5">
-            <color>0,255,0</color>
-        </itemcolor>
-        <itemcolor name="ldavg-15">
-            <color>0,255,0</color>
-        </itemcolor>
-        <itemcolor name="plist-sz">
-            <color>0,255,255</color>
-        </itemcolor>
-        <itemcolor name="runq-sz">
-            <color>255,255,0</color>
         </itemcolor>
         <itemcolor name="coll/s">
             <color>255,0,0</color>
@@ -111,14 +69,68 @@
             <color>255,0,255</color>
             <type>counter</type>
         </itemcolor>
-        <itemcolor name="tps">
-            <color>255,0,0</color>
-        </itemcolor>
         <itemcolor name="bread/s">
             <color>255,0,0</color>
         </itemcolor>
         <itemcolor name="bwrtn/s">
             <color>255,255,0</color>
+        </itemcolor>
+        <itemcolor name="r+w/s">
+            <color>0,127,255</color>
+            <type>counter</type>
+        </itemcolor>
+
+        <itemcolor name="%usr">
+            <color>0,255,0</color>
+        </itemcolor>
+        <itemcolor name="%user">
+            <color>0,255,0</color>
+        </itemcolor>
+        <itemcolor name="%sys">
+            <color>255,0,0</color>
+        </itemcolor>
+        <itemcolor name ="%system">
+            <color>255,0,0</color>
+        </itemcolor>
+        <itemcolor name="%idle">
+            <color>127,127,127</color>
+        </itemcolor>
+        <itemcolor name="%nice">
+            <color>255,255,0</color>
+        </itemcolor>
+        <itemcolor name="%busy">
+            <color>255,255,0</color>
+            <type>gauge</type>
+        </itemcolor>
+        <itemcolor name="%steal">
+            <color>255,127,0</color>
+        </itemcolor>
+        <itemcolor name="%iowait">
+            <color>255,0,127</color>
+        </itemcolor>
+        <itemcolor name="%wio">
+            <color>255,0,127</color>
+        </itemcolor>
+
+        <itemcolor name="ldavg-1">
+            <color>255,0,0</color>
+        </itemcolor>
+        <itemcolor name="ldavg-5">
+            <color>0,255,0</color>
+        </itemcolor>
+        <itemcolor name="ldavg-15">
+            <color>0,255,0</color>
+        </itemcolor>
+
+        <itemcolor name="plist-sz">
+            <color>0,255,255</color>
+        </itemcolor>
+        <itemcolor name="runq-sz">
+            <color>255,255,0</color>
+        </itemcolor>
+
+        <itemcolor name="tps">
+            <color>255,0,0</color>
         </itemcolor>
         <itemcolor name="rtps">
             <color>255,0,255</color>
@@ -126,6 +138,7 @@
         <itemcolor name="wtps">
             <color>0,0,255</color>
         </itemcolor>
+
         <itemcolor name="avwait">
             <color>255,0,0</color>
             <type>gauge</type>
@@ -138,14 +151,6 @@
             <color>255,0,255</color>
             <type>gauge</type>
         </itemcolor>
-        <itemcolor name="r+w/s">
-            <color>0,127,255</color>
-            <type>counter</type>
-        </itemcolor>
-        <itemcolor name="%busy">
-            <color>255,255,0</color>
-            <type>gauge</type>
-        </itemcolor>
     </colors>
-    
+
 </ConfiG>

--- a/src/Config.xml
+++ b/src/Config.xml
@@ -11,155 +11,20 @@
 
 <ConfiG>
     <colors>
-        <itemcolor name="rawch/s">
-            <color>0,255,0</color>
-        </itemcolor>
-        <itemcolor name="canch/s">
-            <color>0,255,255</color>
-        </itemcolor>
-        <itemcolor name="outch/s">
-            <color>255,255,0</color>
-        </itemcolor>
-        <itemcolor name="xmtin/s">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name="proc/s">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name="rcvin/s">
-            <color>0,0,255</color>
-        </itemcolor>
-        <itemcolor name="mdmin/s">
-            <color>255,0,255</color>
-        </itemcolor>
-        <itemcolor name="intr/s">
-            <color>255,127,127</color>
-        </itemcolor>
-        <itemcolor name="coll/s">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name="rxerr/s">
-            <color>255,255,0</color>
-        </itemcolor>
-        <itemcolor name="rxdrop/s">
-            <color>255,0,255</color>
-        </itemcolor>
-        <itemcolor name="rxfram/s">
-            <color>0,255,255</color>
-        </itemcolor>
-        <itemcolor name="rxfifo/s">
-            <color>255,255,255</color>
-        </itemcolor>
-        <itemcolor name="txerr/s">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name="txdrop/s">
-            <color>0,255,0</color>
-        </itemcolor>
-        <itemcolor name="txcarr/s">
-            <color>0,0,255</color>
-        </itemcolor>
-        <itemcolor name="txfifo/s">
-            <color>255,0,255</color>
-        </itemcolor>
-        <itemcolor name="cswch/s">
-            <color>255,0,255</color>
-        </itemcolor>
-        <itemcolor name="blks/s">
-            <color>255,0,255</color>
-            <type>counter</type>
-        </itemcolor>
-        <itemcolor name="bread/s">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name="bwrtn/s">
-            <color>255,255,0</color>
-        </itemcolor>
         <itemcolor name="r+w/s">
-            <color>0,127,255</color>
             <type>counter</type>
-        </itemcolor>
-
-        <itemcolor name="%usr">
-            <color>0,255,0</color>
-        </itemcolor>
-        <itemcolor name="%user">
-            <color>0,255,0</color>
-        </itemcolor>
-        <itemcolor name="%sys">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name ="%system">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name="%idle">
-            <color>127,127,127</color>
-        </itemcolor>
-        <itemcolor name="%nice">
-            <color>255,255,0</color>
         </itemcolor>
         <itemcolor name="%busy">
-            <color>255,255,0</color>
             <type>gauge</type>
         </itemcolor>
-        <itemcolor name="%steal">
-            <color>255,127,0</color>
-        </itemcolor>
-        <itemcolor name="%iowait">
-            <color>255,0,127</color>
-        </itemcolor>
-        <itemcolor name="%wio">
-            <color>255,0,127</color>
-        </itemcolor>
-        <itemcolor name="%irq">
-            <color>175,125,75</color>
-        </itemcolor>
-        <itemcolor name="%soft">
-            <color>125,75,175</color>
-        </itemcolor>
-        <itemcolor name="%guest">
-            <color>75,175,125</color>
-        </itemcolor>
-
-        <itemcolor name="ldavg-1">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name="ldavg-5">
-            <color>0,255,0</color>
-        </itemcolor>
-        <itemcolor name="ldavg-15">
-            <color>0,255,0</color>
-        </itemcolor>
-
-        <itemcolor name="plist-sz">
-            <color>0,255,255</color>
-        </itemcolor>
-        <itemcolor name="runq-sz">
-            <color>255,255,0</color>
-        </itemcolor>
-
-        <itemcolor name="tps">
-            <color>255,0,0</color>
-        </itemcolor>
-        <itemcolor name="rtps">
-            <color>255,0,255</color>
-        </itemcolor>
-        <itemcolor name="wtps">
-            <color>0,0,255</color>
-        </itemcolor>
-
         <itemcolor name="avwait">
-            <color>255,0,0</color>
             <type>gauge</type>
         </itemcolor>
         <itemcolor name="avserv">
-            <color>0,255,0</color>
             <type>gauge</type>
         </itemcolor>
         <itemcolor name="avque">
-            <color>255,0,255</color>
             <type>gauge</type>
         </itemcolor>
     </colors>
-
 </ConfiG>

--- a/src/net/atomique/ksar/GlobalOptions.java
+++ b/src/net/atomique/ksar/GlobalOptions.java
@@ -67,7 +67,7 @@ public class GlobalOptions {
             } catch (ClassNotFoundException ex) {
                 ex.printStackTrace();
             }
-            
+
         }
         for (String parsername : ParserMap.keySet()) {
             is = this.getClass().getResourceAsStream("/" + parsername + ".xml");
@@ -121,8 +121,6 @@ public class GlobalOptions {
         ColumnConfig tmp = columnlist.get(s);
         if (tmp != null) {
             return tmp.getData_color();
-        } else {
-            System.err.println("WARN: color not found for tag " + s);
         }
         return null;
     }
@@ -199,7 +197,7 @@ public class GlobalOptions {
         saveHistory();
     }
 
-    
+
 
     public static void saveHistory() {
         File tmpfile = null;

--- a/src/net/atomique/ksar/XML/ColumnConfig.java
+++ b/src/net/atomique/ksar/XML/ColumnConfig.java
@@ -29,6 +29,7 @@ public class ColumnConfig {
                 Integer blue = new Integer(color_indices[2]);
                 this.data_color = new Color(red, green, blue);
             } catch (NumberFormatException ee) {
+                error_message = ee.getMessage();
             }
         }
     }
@@ -57,7 +58,7 @@ public class ColumnConfig {
     public int getType() {
         return type;
     }
-    
+
     public boolean is_valid() {
         if (data_title == null) {
             error_message = "Column header name not found";
@@ -72,6 +73,13 @@ public class ColumnConfig {
             return false;
         }
         return true;
+    }
+
+    public boolean is_empty() {
+        if ((data_colorstr == null) && (data_color == null)) {
+            return true;
+        }
+        return false;
     }
 
     public String getError_message() {

--- a/src/net/atomique/ksar/XMLConfig.java
+++ b/src/net/atomique/ksar/XMLConfig.java
@@ -37,7 +37,7 @@ public class XMLConfig extends DefaultHandler {
 
     public XMLConfig(String filename) {
         load_config(filename);
-        
+
     }
 
     public XMLConfig(InputStream is) {
@@ -58,7 +58,7 @@ public class XMLConfig extends DefaultHandler {
             // If nothing found, null is returned, for normal processing
             return inputSource;
         }
-    
+
     public void load_config(InputStream is) {
         SAXParserFactory fabric = null;
         SAXParser parser = null;
@@ -161,7 +161,7 @@ public class XMLConfig extends DefaultHandler {
         if ( "HostInfo".equals(qName)) {
             in_hostinfo=true;
         }
-        
+
         // COLORS
         if (in_colors) {
             if ("itemcolor".equals(qName)) {
@@ -270,7 +270,7 @@ public class XMLConfig extends DefaultHandler {
         if ("HostInfo".equals(qName)) {
             in_hostinfo = false;
         }
-        
+
 
 
         if (currentStat != null) {
@@ -284,7 +284,7 @@ public class XMLConfig extends DefaultHandler {
                 currentStat.setDuplicateTime(tempval);
             }
         }
-        
+
         if ("cols".equals(qName)) {
             if (currentPlot != null) {
                 currentPlot.setHeaderStr(tempval);
@@ -306,11 +306,14 @@ public class XMLConfig extends DefaultHandler {
 
 
         if ("itemcolor".equals(qName)) {
-            if (currentColor.is_valid()) {
-                GlobalOptions.getColorlist().put(currentColor.getData_title(), currentColor);
-            } else {
-                System.err.println("Err: " + currentColor.getError_message());
-                currentColor = null;
+            if (!currentColor.is_empty())
+            {
+                if (currentColor.is_valid()) {
+                    GlobalOptions.getColorlist().put(currentColor.getData_title(), currentColor);
+                } else {
+                    System.err.println("Err: " + currentColor.getError_message());
+                    currentColor = null;
+                }
             }
             in_color = false;
         }
@@ -351,7 +354,7 @@ public class XMLConfig extends DefaultHandler {
         }
     }
 
-    
+
     public boolean beenparse = false;
     private String tempval;
     private boolean in_color = false;
@@ -370,6 +373,6 @@ public class XMLConfig extends DefaultHandler {
     private CnxHistory currentCnx = null;
     private HostInfo currentHost = null;
 
-    
+
 }
 


### PR DESCRIPTION
I suggest removing color definitions in the Config.xml by default, because it looks like ksar is able to handle missing ones automatically. This should remove a lot of maintenance time for increasing data in sar files in future. This is related to PR 8, only one of both approaches is needed.

https://github.com/ppalucha/ksar2/pull/8