### PR TITLE
add support for Linux 3.2 / sysstat 10.0.5 (debian 9)

### DIFF
--- a/src/Linux.xml
+++ b/src/Linux.xml
@@ -117,6 +117,11 @@
                 <graphname>KMEM</graphname>
             </Stat>
             
+            <!-- Linux 3.2, sysstat version 10.0.5 -->
+            <Stat name="kmem6">
+                <headerstr>kbmemfree kbmemused %memused kbbuffers kbcached kbcommit %commit kbactive kbinact</headerstr>
+                <graphname>KMEM</graphname>
+            </Stat>
                         
             <Stat name="kswap">
                 <headerstr>kbswpfree kbswpused %swpused kbswpcad %swpcad</headerstr>


### PR DESCRIPTION
Hello,

Memory statistics weren't parsed correctly on our systems running Debian 9, so I added the correct KMEM line in Linux.xml.

Thanks,